### PR TITLE
Fix movie filter lost when paginating

### DIFF
--- a/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
@@ -841,7 +841,7 @@ class AniListBrowser(BrowserBase):
         favourites = database.get(self.get_base_res, 24, variables)
         return self.process_anilist_view(favourites, "all_time_favourites?page=%d", page)
 
-    def get_top_100(self, page, format):
+    def get_top_100(self, page, format, plugin_url="top_100"):
         variables = {
             'page': page,
             'perpage': self.perpage,
@@ -868,7 +868,8 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         top_100 = database.get(self.get_base_res, 24, variables)
-        return self.process_anilist_view(top_100, "top_100?page=%d", page)
+        base_url = f"{plugin_url}?page=%d"
+        return self.process_anilist_view(top_100, base_url, page)
 
     def get_genre_action(self, page, format):
         variables = {

--- a/plugin.video.otaku.testing/resources/lib/Main.py
+++ b/plugin.video.otaku.testing/resources/lib/Main.py
@@ -694,7 +694,7 @@ def TOP_100(payload, params):
     format = None
     if plugin_url in mapping:
         format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
-    control.draw_items(BROWSER.get_top_100(page, format), 'tvshows')
+    control.draw_items(BROWSER.get_top_100(page, format, plugin_url), 'tvshows')
 
 
 @Route('genres/*')

--- a/plugin.video.otaku.testing/resources/lib/MalBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/MalBrowser.py
@@ -971,7 +971,7 @@ class MalBrowser(BrowserBase):
         favourites = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
         return self.process_mal_view(favourites, "all_time_favourites?page=%d", page)
 
-    def get_top_100(self, page, format):
+    def get_top_100(self, page, format, plugin_url="top_100"):
         params = {
             'page': page,
             'limit': self.perpage,
@@ -994,7 +994,8 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         top_100 = database.get(self.get_base_res, 24, f"{self._BASE_URL}/top/anime", params)
-        return self.process_mal_view(top_100, "top_100?page=%d", page)
+        base_url = f"{plugin_url}?page=%d"
+        return self.process_mal_view(top_100, base_url, page)
 
     def get_genre_action(self, page, format):
         params = {


### PR DESCRIPTION
## Summary
- preserve media format when paging through Top 100 lists

## Testing
- `python -m py_compile plugin.video.otaku.testing/resources/lib/Main.py plugin.video.otaku.testing/resources/lib/AniListBrowser.py plugin.video.otaku.testing/resources/lib/MalBrowser.py`

------
https://chatgpt.com/codex/tasks/task_e_68703dd298a0832491c8ef79c133ecc0