### PR TITLE
Fix movie filter lost when paginating

### DIFF
--- a/plugin.video.otaku.testing/resources/lib/ui/BrowserBase.py
+++ b/plugin.video.otaku.testing/resources/lib/ui/BrowserBase.py
@@ -14,9 +14,11 @@ class BrowserBase(object):
     def handle_paging(hasnextpage, base_url, page):
         """Return a menu item for the next page.
 
-        ``base_url`` is preserved for backward compatibility but ignored in
-        favour of building the URL from the current plugin route to keep any
-        active filters intact.
+        ``base_url`` may include query parameters or even a different
+        route when multiple filters are active. ``sys.argv`` provides the
+        current plugin route along with any query string issued for the
+        present page. To preserve filters we merge parameters from both
+        sources and decide which route contains the actual filter path.
         """
 
         if not hasnextpage or not control.is_addon_visible() and control.getBool('widget.hide.nextpage'):
@@ -25,10 +27,28 @@ class BrowserBase(object):
         next_page = page + 1
         name = "Next Page (%d)" % next_page
 
+        # Current route and query parameters
         current_route = control.get_plugin_url(sys.argv[0])
         current_params = dict(urllib.parse.parse_qsl(sys.argv[2].lstrip('?')))
-        current_params['page'] = next_page
-        url = f"{current_route}?{urllib.parse.urlencode(current_params)}"
+
+        # Parameters and route from the provided base URL
+        formatted_base = base_url % next_page
+        if '?' in formatted_base:
+            base_route, base_qs = formatted_base.split('?', 1)
+            base_params = dict(urllib.parse.parse_qsl(base_qs))
+        else:
+            base_route, base_params = formatted_base, {}
+
+        # Choose the most specific route between base and current
+        if current_route.startswith(base_route):
+            route = current_route
+        else:
+            route = base_route
+
+        # Merge parameters giving precedence to existing ones
+        params = {**base_params, **current_params}
+        params['page'] = next_page
+        url = f"{route}?{urllib.parse.urlencode(params)}"
 
         return [utils.allocate_item(name, url, True, False, [], 'next.png', {'plot': name}, 'next.png')]
 


### PR DESCRIPTION
## Summary
- preserve media format when paging through Top 100 lists
- ensure pagination retains the active route for all sections
- keep other query parameters when building Next Page links

## Testing
- `python -m py_compile plugin.video.otaku.testing/resources/lib/Main.py plugin.video.otaku.testing/resources/lib/AniListBrowser.py plugin.video.otaku.testing/resources/lib/MalBrowser.py`


------
https://chatgpt.com/codex/tasks/task_e_68703dd298a0832491c8ef79c133ecc0