### PR TITLE
Fix paging filter retention

### DIFF
--- a/plugin.video.otaku.testing/resources/lib/WatchlistFlavor/Kitsu.py
+++ b/plugin.video.otaku.testing/resources/lib/WatchlistFlavor/Kitsu.py
@@ -67,8 +67,7 @@ class KitsuWLF(WatchlistFlavorBase):
         control.setSetting('kitsu.refresh', data['refresh_token'])
         control.setInt('kitsu.expiry', int(time.time() + int(data['expires_in'])))
 
-    @staticmethod
-    def handle_paging(hasnextpage, base_url, page):
+    def handle_paging(self, hasnextpage, base_url, page):
         if not hasnextpage or not control.is_addon_visible() and control.getBool('widget.hide.nextpage'):
             return []
         next_page = page + 1

--- a/plugin.video.otaku.testing/resources/lib/WatchlistFlavor/MyAnimeList.py
+++ b/plugin.video.otaku.testing/resources/lib/WatchlistFlavor/MyAnimeList.py
@@ -76,8 +76,7 @@ class MyAnimeListWLF(WatchlistFlavorBase):
         control.setSetting('mal.refresh', res['refresh_token'])
         control.setInt('mal.expiry', int(time.time()) + int(res['expires_in']))
 
-    @staticmethod
-    def handle_paging(hasnextpage, base_url, page):
+    def handle_paging(self, hasnextpage, base_url, page):
         if not hasnextpage or not control.is_addon_visible() and control.getBool('widget.hide.nextpage'):
             return []
         next_page = page + 1

--- a/plugin.video.otaku.testing/resources/lib/ui/BrowserBase.py
+++ b/plugin.video.otaku.testing/resources/lib/ui/BrowserBase.py
@@ -9,13 +9,23 @@ from resources.lib.ui import client, control, utils
 class BrowserBase(object):
     _BASE_URL = None
 
-    @staticmethod
-    def handle_paging(hasnextpage, base_url, page):
+    def set_current_path(self, path):
+        self._current_path = path
+
+    def handle_paging(self, hasnextpage, base_url, page):
         if not hasnextpage or not control.is_addon_visible() and control.getBool('widget.hide.nextpage'):
             return []
         next_page = page + 1
         name = "Next Page (%d)" % next_page
-        return [utils.allocate_item(name, base_url % next_page, True, False, [], 'next.png', {'plot': name}, 'next.png')]
+        url = base_url % next_page
+        plugin_path = getattr(self, '_current_path', None)
+        if plugin_path:
+            if '?' in url:
+                _, query = url.split('?', 1)
+                url = f'{plugin_path}?{query}'
+            else:
+                url = plugin_path
+        return [utils.allocate_item(name, url, True, False, [], 'next.png', {'plot': name}, 'next.png')]
 
     @staticmethod
     def open_completed():

--- a/plugin.video.otaku.testing/resources/lib/ui/router.py
+++ b/plugin.video.otaku.testing/resources/lib/ui/router.py
@@ -18,6 +18,8 @@ class Route:
 def router_process(url, params=None):
     if not params:
         params = {}
+    from resources.lib import OtakuBrowser
+    OtakuBrowser.BROWSER.set_current_path(url)
     payload = "/".join(url.split("/")[1:])
     for route_obj in ROUTES:
         if url == route_obj.path or (route_obj.wildcard and url.startswith(route_obj.path)):


### PR DESCRIPTION
## Summary
- keep plugin route when generating next page links
- update watchlist paging helpers
- track current path in router

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726dbf72a083248837b9d435508066