### PR TITLE
Fix movie genre paging filter

### DIFF
--- a/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
@@ -1348,7 +1348,13 @@ class AniListBrowser(BrowserBase):
             for i in search_adult["ANIME"]:
                 i['title']['english'] = f'{i["title"]["english"]} - {control.colorstr("Adult", "red")}'
             search['ANIME'] += search_adult['ANIME']
-        return self.process_anilist_view(search, f"search_anime/{query}?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('/', 1)[0]
+            base_plugin_url = f"{prefix}/{query}?page=%d"
+        except Exception:
+            base_plugin_url = f"search_anime/{query}?page=%d"
+        return self.process_anilist_view(search, base_plugin_url, page)
 
     def get_recommendations(self, mal_id, page):
         variables = {

--- a/plugin.video.otaku.testing/resources/lib/Main.py
+++ b/plugin.video.otaku.testing/resources/lib/Main.py
@@ -718,8 +718,9 @@ def GENRES(payload, params):
     genres, tags = payload.rsplit("/")
     page = int(params.get('page', 1))
     format = None
-    if plugin_url in mapping:
-        format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
+    base_key = plugin_url.split('/', 1)[0] + '//'
+    if base_key in mapping:
+        format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
     if genres or tags:
         control.draw_items(BROWSER.genres_payload(genres, tags, page, format), 'tvshows')
     else:

--- a/plugin.video.otaku.testing/resources/lib/MalBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/MalBrowser.py
@@ -335,7 +335,13 @@ class MalBrowser(BrowserBase):
             params['type'] = self.format_in_type
 
         search = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        return self.process_mal_view(search, f"search_anime/{query}?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('/', 1)[0]
+            base_plugin_url = f"{prefix}/{query}?page=%d"
+        except Exception:
+            base_plugin_url = f"search_anime/{query}?page=%d"
+        return self.process_mal_view(search, base_plugin_url, page)
 
     def get_airing_last_season(self, page, format):
         season, year, _, _, _, _, _, _, _, _, _, _, _, _ = self.get_season_year('last')


### PR DESCRIPTION
## Summary
- ensure movie genre routes persist format on additional pages
- preserve movie filter for search paging

## Testing
- `python -m py_compile plugin.video.otaku.testing/resources/lib/Main.py`
- `python -m py_compile plugin.video.otaku.testing/resources/lib/AniListBrowser.py plugin.video.otaku.testing/resources/lib/MalBrowser.py`


------
https://chatgpt.com/codex/tasks/task_e_6872f01e58208324b4c884efc1e5b9c8