### PR TITLE
Fix movie genre paging filter

### DIFF
--- a/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
@@ -250,7 +250,13 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        return self.process_anilist_view(trending, "trending_last_year?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "trending_last_year?page=%d"
+        return self.process_anilist_view(trending, base_plugin_url, page)
 
     def get_trending_this_year(self, page, format):
         season, year = self.get_season_year('')
@@ -281,7 +287,13 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        return self.process_anilist_view(trending, "trending_this_year?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "trending_this_year?page=%d"
+        return self.process_anilist_view(trending, base_plugin_url, page)
 
     def get_trending_last_season(self, page, format):
         season, year = self.get_season_year('last')
@@ -313,7 +325,13 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        return self.process_anilist_view(trending, "trending_last_season?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "trending_last_season?page=%d"
+        return self.process_anilist_view(trending, base_plugin_url, page)
 
     def get_trending_this_season(self, page, format):
         season, year = self.get_season_year('this')
@@ -345,7 +363,13 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        return self.process_anilist_view(trending, "trending_this_season?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "trending_this_season?page=%d"
+        return self.process_anilist_view(trending, base_plugin_url, page)
 
     def get_all_time_trending(self, page, format):
         variables = {
@@ -374,7 +398,13 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        return self.process_anilist_view(trending, "all_time_trending?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "all_time_trending?page=%d"
+        return self.process_anilist_view(trending, base_plugin_url, page)
 
     def get_popular_last_year(self, page, format):
         season, year = self.get_season_year('')
@@ -1348,7 +1378,13 @@ class AniListBrowser(BrowserBase):
             for i in search_adult["ANIME"]:
                 i['title']['english'] = f'{i["title"]["english"]} - {control.colorstr("Adult", "red")}'
             search['ANIME'] += search_adult['ANIME']
-        return self.process_anilist_view(search, f"search_anime/{query}?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('/', 1)[0]
+            base_plugin_url = f"{prefix}/{query}?page=%d"
+        except Exception:
+            base_plugin_url = f"search_anime/{query}?page=%d"
+        return self.process_anilist_view(search, base_plugin_url, page)
 
     def get_recommendations(self, mal_id, page):
         variables = {

--- a/plugin.video.otaku.testing/resources/lib/Main.py
+++ b/plugin.video.otaku.testing/resources/lib/Main.py
@@ -117,8 +117,9 @@ def AIRING_LAST_SEASON(payload, params):
     }
     page = int(params.get('page', 1))
     format = None
-    if plugin_url in mapping:
-        format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
+    base_key = plugin_url.split('?', 1)[0]
+    if base_key in mapping:
+        format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
     control.draw_items(BROWSER.get_airing_last_season(page, format), 'tvshows')
 
 
@@ -142,8 +143,9 @@ def AIRING_THIS_SEASON(payload, params):
     }
     page = int(params.get('page', 1))
     format = None
-    if plugin_url in mapping:
-        format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
+    base_key = plugin_url.split('?', 1)[0]
+    if base_key in mapping:
+        format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
     control.draw_items(BROWSER.get_airing_this_season(page, format), 'tvshows')
 
 
@@ -167,8 +169,9 @@ def AIRING_NEXT_SEASON(payload, params):
     }
     page = int(params.get('page', 1))
     format = None
-    if plugin_url in mapping:
-        format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
+    base_key = plugin_url.split('?', 1)[0]
+    if base_key in mapping:
+        format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
     control.draw_items(BROWSER.get_airing_next_season(page, format), 'tvshows')
 
 
@@ -192,8 +195,9 @@ def TRENDING_LAST_YEAR(payload, params):
     }
     page = int(params.get('page', 1))
     format = None
-    if plugin_url in mapping:
-        format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
+    base_key = plugin_url.split('?', 1)[0]
+    if base_key in mapping:
+        format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
     control.draw_items(BROWSER.get_trending_last_year(page, format), 'tvshows')
 
 
@@ -217,8 +221,9 @@ def TRENDING_THIS_YEAR(payload, params):
     }
     page = int(params.get('page', 1))
     format = None
-    if plugin_url in mapping:
-        format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
+    base_key = plugin_url.split('?', 1)[0]
+    if base_key in mapping:
+        format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
     control.draw_items(BROWSER.get_trending_this_year(page, format), 'tvshows')
 
 
@@ -242,8 +247,9 @@ def TRENDING_LAST_SEASON(payload, params):
     }
     page = int(params.get('page', 1))
     format = None
-    if plugin_url in mapping:
-        format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
+    base_key = plugin_url.split('?', 1)[0]
+    if base_key in mapping:
+        format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
     control.draw_items(BROWSER.get_trending_last_season(page, format), 'tvshows')
 
 
@@ -718,8 +724,9 @@ def GENRES(payload, params):
     genres, tags = payload.rsplit("/")
     page = int(params.get('page', 1))
     format = None
-    if plugin_url in mapping:
-        format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
+    base_key = plugin_url.split('/', 1)[0] + '//'
+    if base_key in mapping:
+        format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
     if genres or tags:
         control.draw_items(BROWSER.genres_payload(genres, tags, page, format), 'tvshows')
     else:

--- a/plugin.video.otaku.testing/resources/lib/MalBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/MalBrowser.py
@@ -335,7 +335,13 @@ class MalBrowser(BrowserBase):
             params['type'] = self.format_in_type
 
         search = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        return self.process_mal_view(search, f"search_anime/{query}?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('/', 1)[0]
+            base_plugin_url = f"{prefix}/{query}?page=%d"
+        except Exception:
+            base_plugin_url = f"search_anime/{query}?page=%d"
+        return self.process_mal_view(search, base_plugin_url, page)
 
     def get_airing_last_season(self, page, format):
         season, year, _, _, _, _, _, _, _, _, _, _, _, _ = self.get_season_year('last')
@@ -416,7 +422,13 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        return self.process_mal_view(trending, "trending_last_year?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "trending_last_year?page=%d"
+        return self.process_mal_view(trending, base_plugin_url, page)
 
     def get_trending_this_year(self, page, format):
         _, _, year_start_date, _, _, _, _, _, _, _, _, _, _, _ = self.get_season_year('')
@@ -445,7 +457,13 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        return self.process_mal_view(trending, "trending_this_year?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "trending_this_year?page=%d"
+        return self.process_mal_view(trending, base_plugin_url, page)
 
     def get_trending_last_season(self, page, format):
         _, _, _, _, _, _, season_start_date_last, season_end_date_last, _, _, _, _, _, _ = self.get_season_year('')
@@ -475,7 +493,13 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        return self.process_mal_view(trending, "trending_last_season?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "trending_last_season?page=%d"
+        return self.process_mal_view(trending, base_plugin_url, page)
 
     def get_trending_this_season(self, page, format):
         _, _, _, _, season_start_date, _, _, _, _, _, _, _, _, _ = self.get_season_year('')
@@ -504,7 +528,13 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        return self.process_mal_view(trending, "trending_this_season?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "trending_this_season?page=%d"
+        return self.process_mal_view(trending, base_plugin_url, page)
 
     def get_all_time_trending(self, page, format):
         params = {
@@ -531,7 +561,13 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        return self.process_mal_view(trending, "all_time_trending?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('?', 1)[0]
+            base_plugin_url = f"{prefix}?page=%d"
+        except Exception:
+            base_plugin_url = "all_time_trending?page=%d"
+        return self.process_mal_view(trending, base_plugin_url, page)
 
     def get_popular_last_year(self, page, format):
         _, _, _, _, _, _, _, _, year_start_date_last, year_end_date_last, _, _, _, _ = self.get_season_year('')
@@ -1573,7 +1609,13 @@ class MalBrowser(BrowserBase):
             params['rating'] = self.rating
 
         genres = database.get(self.get_base_res, 24, f'{self._BASE_URL}/anime', params)
-        return self.process_mal_view(genres, f"genres/{genre_list}/{tag_list}?page=%d", page)
+        try:
+            from resources.lib import Main
+            prefix = Main.plugin_url.split('/', 1)[0]
+            base_plugin_url = f"{prefix}/{genre_list}/{tag_list}?page=%d"
+        except Exception:
+            base_plugin_url = f"genres/{genre_list}/{tag_list}?page=%d"
+        return self.process_mal_view(genres, base_plugin_url, page)
 
     @div_flavor
     def base_mal_view(self, res, completed=None, mal_dub=None):


### PR DESCRIPTION
## Summary
- ensure movie genre routes persist format on additional pages
- preserve movie filter for search paging
- retain selected format when paging trending lists
- fix movie genre paging for MAL

## Testing
- `python -m py_compile plugin.video.otaku.testing/resources/lib/Main.py`
- `python -m py_compile plugin.video.otaku.testing/resources/lib/AniListBrowser.py plugin.video.otaku.testing/resources/lib/MalBrowser.py`


------
https://chatgpt.com/codex/tasks/task_e_6872f01e58208324b4c884efc1e5b9c8