### PR TITLE
Remove Main import loops

### DIFF
--- a/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
@@ -16,6 +16,7 @@ class AniListBrowser(BrowserBase):
     _BASE_URL = "https://graphql.anilist.co"
 
     def __init__(self):
+        super().__init__()
         self.title_lang = ["romaji", 'english'][control.getInt("titlelanguage")]
         self.perpage = control.getInt('interface.perpage.general.anilist')
         self.year_type = control.getInt('contentyear.menu') if control.getBool('contentyear.bool') else 0
@@ -250,11 +251,10 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "trending_last_year?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
@@ -287,11 +287,10 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "trending_this_year?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
@@ -325,11 +324,10 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "trending_last_season?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
@@ -363,11 +361,10 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "trending_this_season?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
@@ -398,11 +395,10 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "all_time_trending?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
@@ -1378,11 +1374,10 @@ class AniListBrowser(BrowserBase):
             for i in search_adult["ANIME"]:
                 i['title']['english'] = f'{i["title"]["english"]} - {control.colorstr("Adult", "red")}'
             search['ANIME'] += search_adult['ANIME']
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('/', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('/', 1)[0]
             base_plugin_url = f"{prefix}/{query}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = f"search_anime/{query}?page=%d"
         return self.process_anilist_view(search, base_plugin_url, page)
 
@@ -2553,11 +2548,10 @@ class AniListBrowser(BrowserBase):
         if format:
             variables['format'] = format
 
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('/', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('/', 1)[0]
             base_plugin_url = f"{prefix}/{genre_list}/{tag_list}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = f"genres/{genre_list}/{tag_list}?page=%d"
 
         return self.process_genre_view(query, variables, base_plugin_url, page)

--- a/plugin.video.otaku.testing/resources/lib/Main.py
+++ b/plugin.video.otaku.testing/resources/lib/Main.py
@@ -28,6 +28,7 @@ from resources.lib.WatchlistIntegration import add_watchlist
 
 BROWSER = OtakuBrowser.BROWSER
 plugin_url = control.get_plugin_url(sys.argv[0])
+BROWSER.set_plugin_url(plugin_url)
 
 
 def add_last_watched(items):

--- a/plugin.video.otaku.testing/resources/lib/MalBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/MalBrowser.py
@@ -19,6 +19,7 @@ class MalBrowser(BrowserBase):
     _BASE_URL = "https://api.jikan.moe/v4"
 
     def __init__(self):
+        super().__init__()
         self.title_lang = ['title', 'title_english'][control.getInt("titlelanguage")]
         self.perpage = control.getInt('interface.perpage.general.mal')
         self.year_type = control.getInt('contentyear.menu') if control.getBool('contentyear.bool') else 0
@@ -335,11 +336,10 @@ class MalBrowser(BrowserBase):
             params['type'] = self.format_in_type
 
         search = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('/', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('/', 1)[0]
             base_plugin_url = f"{prefix}/{query}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = f"search_anime/{query}?page=%d"
         return self.process_mal_view(search, base_plugin_url, page)
 
@@ -422,11 +422,10 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "trending_last_year?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
@@ -457,11 +456,10 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "trending_this_year?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
@@ -493,11 +491,10 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "trending_last_season?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
@@ -528,11 +525,10 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "trending_this_season?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
@@ -561,11 +557,10 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('?', 1)[0]
             base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = "all_time_trending?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
@@ -1609,11 +1604,10 @@ class MalBrowser(BrowserBase):
             params['rating'] = self.rating
 
         genres = database.get(self.get_base_res, 24, f'{self._BASE_URL}/anime', params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('/', 1)[0]
+        if self.plugin_url:
+            prefix = self.plugin_url.split('/', 1)[0]
             base_plugin_url = f"{prefix}/{genre_list}/{tag_list}?page=%d"
-        except Exception:
+        else:
             base_plugin_url = f"genres/{genre_list}/{tag_list}?page=%d"
         return self.process_mal_view(genres, base_plugin_url, page)
 

--- a/plugin.video.otaku.testing/resources/lib/ui/BrowserBase.py
+++ b/plugin.video.otaku.testing/resources/lib/ui/BrowserBase.py
@@ -9,8 +9,13 @@ from resources.lib.ui import client, control, utils
 class BrowserBase(object):
     _BASE_URL = None
 
-    @staticmethod
-    def handle_paging(hasnextpage, base_url, page):
+    def __init__(self):
+        self.plugin_url = None
+
+    def set_plugin_url(self, plugin_url):
+        self.plugin_url = plugin_url
+
+    def handle_paging(self, hasnextpage, base_url, page):
         if not hasnextpage or not control.is_addon_visible() and control.getBool('widget.hide.nextpage'):
             return []
 
@@ -21,13 +26,9 @@ class BrowserBase(object):
 
         url_path, sep, query = next_url.partition('?')
 
-        try:
-            from resources.lib import Main
-            plugin_path = getattr(Main, 'plugin_url', '')
-            if plugin_path and plugin_path.startswith(url_path):
-                url_path = plugin_path
-        except Exception:
-            pass
+        plugin_path = getattr(self, 'plugin_url', '')
+        if plugin_path and plugin_path.startswith(url_path):
+            url_path = plugin_path
 
         next_url = url_path + (sep + query if query else '')
 


### PR DESCRIPTION
## Summary
- allow BrowserBase to store plugin prefix
- remove Main imports from AniListBrowser and MalBrowser
- set plugin prefix in Main module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875a896b7a08324aa1e07e4518886c0