### PR TITLE
Remove circular imports in browsers

### DIFF
--- a/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/AniListBrowser.py
@@ -221,7 +221,7 @@ class AniListBrowser(BrowserBase):
         airing = database.get(self.get_base_res, 24, variables)
         return self.process_anilist_view(airing, "airing_next_season?page=%d", page)
 
-    def get_trending_last_year(self, page, format):
+    def get_trending_last_year(self, page, format, prefix=None):
         season, year = self.get_season_year('')
         variables = {
             'page': page,
@@ -250,15 +250,10 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "trending_last_year?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "trending_last_year?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
-    def get_trending_this_year(self, page, format):
+    def get_trending_this_year(self, page, format, prefix=None):
         season, year = self.get_season_year('')
         variables = {
             'page': page,
@@ -287,15 +282,10 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "trending_this_year?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "trending_this_year?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
-    def get_trending_last_season(self, page, format):
+    def get_trending_last_season(self, page, format, prefix=None):
         season, year = self.get_season_year('last')
         variables = {
             'page': page,
@@ -325,15 +315,10 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "trending_last_season?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "trending_last_season?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
-    def get_trending_this_season(self, page, format):
+    def get_trending_this_season(self, page, format, prefix=None):
         season, year = self.get_season_year('this')
         variables = {
             'page': page,
@@ -363,15 +348,10 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "trending_this_season?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "trending_this_season?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
-    def get_all_time_trending(self, page, format):
+    def get_all_time_trending(self, page, format, prefix=None):
         variables = {
             'page': page,
             'perpage': self.perpage,
@@ -398,12 +378,7 @@ class AniListBrowser(BrowserBase):
             variables['includedTags'] = self.tag
 
         trending = database.get(self.get_base_res, 24, variables)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "all_time_trending?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "all_time_trending?page=%d"
         return self.process_anilist_view(trending, base_plugin_url, page)
 
     def get_popular_last_year(self, page, format):
@@ -1356,7 +1331,7 @@ class AniListBrowser(BrowserBase):
         genre = database.get(self.get_base_res, 24, variables)
         return self.process_anilist_view(genre, "genre_thriller?page=%d", page)
 
-    def get_search(self, query, page, format):
+    def get_search(self, query, page, format, prefix=None):
         variables = {
             'page': page,
             'perpage': self.perpage,
@@ -1378,12 +1353,7 @@ class AniListBrowser(BrowserBase):
             for i in search_adult["ANIME"]:
                 i['title']['english'] = f'{i["title"]["english"]} - {control.colorstr("Adult", "red")}'
             search['ANIME'] += search_adult['ANIME']
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('/', 1)[0]
-            base_plugin_url = f"{prefix}/{query}?page=%d"
-        except Exception:
-            base_plugin_url = f"search_anime/{query}?page=%d"
+        base_plugin_url = f"{prefix}/{query}?page=%d" if prefix else f"search_anime/{query}?page=%d"
         return self.process_anilist_view(search, base_plugin_url, page)
 
     def get_recommendations(self, mal_id, page):
@@ -2425,7 +2395,7 @@ class AniListBrowser(BrowserBase):
                 tag_display_list.append(tags_list[selection - len(genres_list)])
         return self.genres_payload(genre_display_list, tag_display_list, page, format)
 
-    def genres_payload(self, genre_list, tag_list, page, format):
+    def genres_payload(self, genre_list, tag_list, page, format, prefix=None):
         query = '''
         query (
             $page: Int=1,
@@ -2553,12 +2523,7 @@ class AniListBrowser(BrowserBase):
         if format:
             variables['format'] = format
 
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('/', 1)[0]
-            base_plugin_url = f"{prefix}/{genre_list}/{tag_list}?page=%d"
-        except Exception:
-            base_plugin_url = f"genres/{genre_list}/{tag_list}?page=%d"
+        base_plugin_url = f"{prefix}/{genre_list}/{tag_list}?page=%d" if prefix else f"genres/{genre_list}/{tag_list}?page=%d"
 
         return self.process_genre_view(query, variables, base_plugin_url, page)
 

--- a/plugin.video.otaku.testing/resources/lib/Main.py
+++ b/plugin.video.otaku.testing/resources/lib/Main.py
@@ -198,7 +198,8 @@ def TRENDING_LAST_YEAR(payload, params):
     base_key = plugin_url.split('?', 1)[0]
     if base_key in mapping:
         format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
-    control.draw_items(BROWSER.get_trending_last_year(page, format), 'tvshows')
+    prefix = plugin_url.split('?', 1)[0]
+    control.draw_items(BROWSER.get_trending_last_year(page, format, prefix), 'tvshows')
 
 
 @Route('trending_this_year')
@@ -224,7 +225,8 @@ def TRENDING_THIS_YEAR(payload, params):
     base_key = plugin_url.split('?', 1)[0]
     if base_key in mapping:
         format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
-    control.draw_items(BROWSER.get_trending_this_year(page, format), 'tvshows')
+    prefix = plugin_url.split('?', 1)[0]
+    control.draw_items(BROWSER.get_trending_this_year(page, format, prefix), 'tvshows')
 
 
 @Route('trending_last_season')
@@ -250,7 +252,8 @@ def TRENDING_LAST_SEASON(payload, params):
     base_key = plugin_url.split('?', 1)[0]
     if base_key in mapping:
         format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
-    control.draw_items(BROWSER.get_trending_last_season(page, format), 'tvshows')
+    prefix = plugin_url.split('?', 1)[0]
+    control.draw_items(BROWSER.get_trending_last_season(page, format, prefix), 'tvshows')
 
 
 @Route('trending_this_season')
@@ -275,7 +278,8 @@ def TRENDING_THIS_SEASON(payload, params):
     format = None
     if plugin_url in mapping:
         format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
-    control.draw_items(BROWSER.get_trending_this_season(page, format), 'tvshows')
+    prefix = plugin_url.split('?', 1)[0]
+    control.draw_items(BROWSER.get_trending_this_season(page, format, prefix), 'tvshows')
 
 
 @Route('all_time_trending')
@@ -300,7 +304,8 @@ def ALL_TIME_TRENDING(payload, params):
     format = None
     if plugin_url in mapping:
         format = mapping[plugin_url][0] if control.settingids.browser_api == 'mal' else mapping[plugin_url][1]
-    control.draw_items(BROWSER.get_all_time_trending(page, format), 'tvshows')
+    prefix = plugin_url.split('?', 1)[0]
+    control.draw_items(BROWSER.get_all_time_trending(page, format, prefix), 'tvshows')
 
 
 @Route('popular_last_year')
@@ -728,7 +733,8 @@ def GENRES(payload, params):
     if base_key in mapping:
         format = mapping[base_key][0] if control.settingids.browser_api == 'mal' else mapping[base_key][1]
     if genres or tags:
-        control.draw_items(BROWSER.genres_payload(genres, tags, page, format), 'tvshows')
+        prefix = plugin_url.split('/', 1)[0]
+        control.draw_items(BROWSER.genres_payload(genres, tags, page, format, prefix), 'tvshows')
     else:
         control.draw_items(BROWSER.get_genres(page, format), 'tvshows')
 
@@ -1356,7 +1362,8 @@ def SEARCH(payload, params):
             return control.draw_items([], 'tvshows')
         if control.getInt('searchhistory') == 0:
             database.addSearchHistory(query, type)
-    control.draw_items(BROWSER.get_search(query, page, format), 'tvshows')
+    prefix = plugin_url.split('/', 1)[0]
+    control.draw_items(BROWSER.get_search(query, page, format, prefix), 'tvshows')
 
 
 @Route('play/*')

--- a/plugin.video.otaku.testing/resources/lib/MalBrowser.py
+++ b/plugin.video.otaku.testing/resources/lib/MalBrowser.py
@@ -320,7 +320,7 @@ class MalBrowser(BrowserBase):
         all_results = list(map(mapfunc, watch_order_list))
         return all_results
 
-    def get_search(self, query, page, format):
+    def get_search(self, query, page, format, prefix=None):
         params = {
             "q": query,
             "page": page,
@@ -335,12 +335,7 @@ class MalBrowser(BrowserBase):
             params['type'] = self.format_in_type
 
         search = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('/', 1)[0]
-            base_plugin_url = f"{prefix}/{query}?page=%d"
-        except Exception:
-            base_plugin_url = f"search_anime/{query}?page=%d"
+        base_plugin_url = f"{prefix}/{query}?page=%d" if prefix else f"search_anime/{query}?page=%d"
         return self.process_mal_view(search, base_plugin_url, page)
 
     def get_airing_last_season(self, page, format):
@@ -394,7 +389,7 @@ class MalBrowser(BrowserBase):
         airing = database.get(self.get_base_res, 24, f"{self._BASE_URL}/seasons/{year}/{season}", params)
         return self.process_mal_view(airing, "airing_next_season?page=%d", page)
 
-    def get_trending_last_year(self, page, format):
+    def get_trending_last_year(self, page, format, prefix=None):
         _, _, _, _, _, _, _, _, year_start_date_last, year_end_date_last, _, _, _, _ = self.get_season_year('last')
         params = {
             'page': page,
@@ -422,15 +417,10 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "trending_last_year?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "trending_last_year?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
-    def get_trending_this_year(self, page, format):
+    def get_trending_this_year(self, page, format, prefix=None):
         _, _, year_start_date, _, _, _, _, _, _, _, _, _, _, _ = self.get_season_year('')
         params = {
             'page': page,
@@ -457,15 +447,10 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "trending_this_year?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "trending_this_year?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
-    def get_trending_last_season(self, page, format):
+    def get_trending_last_season(self, page, format, prefix=None):
         _, _, _, _, _, _, season_start_date_last, season_end_date_last, _, _, _, _, _, _ = self.get_season_year('')
         params = {
             'page': page,
@@ -493,15 +478,10 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "trending_last_season?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "trending_last_season?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
-    def get_trending_this_season(self, page, format):
+    def get_trending_this_season(self, page, format, prefix=None):
         _, _, _, _, season_start_date, _, _, _, _, _, _, _, _, _ = self.get_season_year('')
         params = {
             'page': page,
@@ -528,15 +508,10 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "trending_this_season?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "trending_this_season?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
-    def get_all_time_trending(self, page, format):
+    def get_all_time_trending(self, page, format, prefix=None):
         params = {
             'page': page,
             'limit': self.perpage,
@@ -561,12 +536,7 @@ class MalBrowser(BrowserBase):
             params['genres'] = self.genre
 
         trending = database.get(self.get_base_res, 24, f"{self._BASE_URL}/anime", params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('?', 1)[0]
-            base_plugin_url = f"{prefix}?page=%d"
-        except Exception:
-            base_plugin_url = "all_time_trending?page=%d"
+        base_plugin_url = f"{prefix}?page=%d" if prefix else "all_time_trending?page=%d"
         return self.process_mal_view(trending, base_plugin_url, page)
 
     def get_popular_last_year(self, page, format):
@@ -1583,7 +1553,7 @@ class MalBrowser(BrowserBase):
                 genre_display_list.append(str(genre[selection]['mal_id']))
         return self.genres_payload(genre_display_list, [], page, format)
 
-    def genres_payload(self, genre_list, tag_list, page, format):
+    def genres_payload(self, genre_list, tag_list, page, format, prefix=None):
         if not isinstance(genre_list, list):
             genre_list = ast.literal_eval(genre_list)
 
@@ -1609,12 +1579,7 @@ class MalBrowser(BrowserBase):
             params['rating'] = self.rating
 
         genres = database.get(self.get_base_res, 24, f'{self._BASE_URL}/anime', params)
-        try:
-            from resources.lib import Main
-            prefix = Main.plugin_url.split('/', 1)[0]
-            base_plugin_url = f"{prefix}/{genre_list}/{tag_list}?page=%d"
-        except Exception:
-            base_plugin_url = f"genres/{genre_list}/{tag_list}?page=%d"
+        base_plugin_url = f"{prefix}/{genre_list}/{tag_list}?page=%d" if prefix else f"genres/{genre_list}/{tag_list}?page=%d"
         return self.process_mal_view(genres, base_plugin_url, page)
 
     @div_flavor

--- a/plugin.video.otaku.testing/resources/lib/ui/BrowserBase.py
+++ b/plugin.video.otaku.testing/resources/lib/ui/BrowserBase.py
@@ -19,18 +19,6 @@ class BrowserBase(object):
 
         next_url = base_url % next_page
 
-        url_path, sep, query = next_url.partition('?')
-
-        try:
-            from resources.lib import Main
-            plugin_path = getattr(Main, 'plugin_url', '')
-            if plugin_path and plugin_path.startswith(url_path):
-                url_path = plugin_path
-        except Exception:
-            pass
-
-        next_url = url_path + (sep + query if query else '')
-
         return [utils.allocate_item(name, next_url, True, False, [], 'next.png', {'plot': name}, 'next.png')]
 
     @staticmethod


### PR DESCRIPTION
## Summary
- simplify pagination URL handling
- accept optional prefix parameters for URL building
- pass prefix in the main routing functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875a896b7a08324aa1e07e4518886c0